### PR TITLE
reduced visual noise of displayed durations

### DIFF
--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -163,6 +163,11 @@ impl TestRunner {
         else if self.time_unit == TEST_RUNNER_TIME_UNITS.microseconds {
             duration /= 1000 as DurationType;
         }
+        let precision = match duration {
+            _ if duration < 1.0 => 2_usize,
+            _ if duration < 10.0 => 1_usize,
+            _ => 0_usize,
+        };
         let test_info = TestCaseResults {
             title: test.title,
             criteria: test.criteria,
@@ -170,10 +175,10 @@ impl TestRunner {
             status: status.clone(),
         };
         if self.module_path.len() > 0 {
-            println!("{} {}::{}: {} ({}{})", mark, self.module_path, test.title, formatted_criteria, test_info.duration, self.time_unit.1);
+            println!("{} {}::{}: {} ({:.*}{})",mark, self.module_path, test.title, formatted_criteria, precision, test_info.duration, self.time_unit.1);
         }
         else {
-            println!("{} {}: {} ({}{})", mark, test.title, formatted_criteria, test_info.duration, self.time_unit.1);
+            println!("{} {}: {} ({:.*}{})",mark, test.title, formatted_criteria, precision, test_info.duration, self.time_unit.1);
         }
         self.results.push(test_info);
         return status == TestCaseStatus::PASSED;


### PR DESCRIPTION
set duration significant digits output not to exceed 2 decimal places, but to not discard any whole unit precision.
<a href='#crh-start'></a><a href='#crh-data-%7B%7D'></a>
<a href='https://www.codereviewhub.com/'><img src='http://www.codereviewhub.com/site/github-bar.png' height=40></a>
<a href='https://www.codereviewhub.com/Alkass/polish/pull/28?approve=1'><img src='http://www.codereviewhub.com/site/github-approve.png' height=26></a>&nbsp;<a href='https://github.com/Alkass/polish/pull/28'><img src='http://www.codereviewhub.com/site/github-refresh.png' height=26></a>
<a href='#crh-end'></a>