### PR TITLE
Fix script and use 2021 edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,6 +2,7 @@
 name = "polish"
 description = "Test-Driven Development done right"
 version = "0.9.9"
+edition = "2021"
 authors = ["Fadi Hanna Al-Kass"]
 documentation = "https://docs.rs/polish"
 homepage = "https://github.com/AlKass/polish"

--- a/makefile
+++ b/makefile
@@ -1,2 +1,2 @@
 test:
-        bash scripts/test.sh
+	bash scripts/test.sh

--- a/makefile
+++ b/makefile
@@ -1,2 +1,2 @@
 test:
-	. scripts/test.sh
+        bash scripts/test.sh

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,11 +1,13 @@
+#!/usr/bin/env bash
+
 for example in examples/*.rs; do
-  echo $example
-  cp $example src/main.rs
+  echo "$example"
+  cp "$example" src/main.rs
   cargo run
   rv=$?
   if [ $rv -ne 0 ]; then
-    echo returning $rv
-    return $rv
+    echo "returning $rv"
+    exit $rv
   fi
 done
 rm src/main.rs

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,2 @@
-extern crate chrono;
-extern crate ansi_term;
-extern crate time;
-
 pub mod logger;
 pub mod test_case;

--- a/src/test_case.rs
+++ b/src/test_case.rs
@@ -2,7 +2,7 @@ use time::OffsetDateTime;
 use chrono::prelude::Local;
 use ansi_term::Colour;
 use ansi_term::Colour::{Green, Red, Yellow};
-use logger::Logger;
+use crate::logger::Logger;
 
 #[derive(PartialEq, Clone)]
 pub enum TestCaseStatus {


### PR DESCRIPTION
## Summary
- set Cargo edition to 2021
- adjust module paths for Rust 2021
- make test script executable directly
- run test script from makefile

## Testing
- `cargo check`
- `bash scripts/test.sh`

------
https://chatgpt.com/codex/tasks/task_e_686317f25c38832db787346e498e16a4